### PR TITLE
sclockadj2: initial implementation of sclockadj2 using adjtimex syscall

### DIFF
--- a/usr/lib/pymodules/python2.7/sdwdate/adjtimex.py
+++ b/usr/lib/pymodules/python2.7/sdwdate/adjtimex.py
@@ -1,0 +1,355 @@
+# coding: utf-8
+
+#  Copyright (C) 2014 Anthon van der Neut <anthon@mnt.org>
+#  Copyright (C) 2014 Patrick Schleizer <adrelanos@riseup.net>
+#  See the file COPYING for copying conditions.
+
+from __future__ import print_function
+
+import os
+import sys
+import errno
+import time
+import math
+
+import ctypes
+from ctypes import Structure, c_int, c_long, c_void_p, pointer
+
+libc = ctypes.CDLL('libc.so.6')
+libc.adjtimex.argtypes = [c_void_p]
+
+
+class TimeVal(Structure):
+    _fields_ = [
+        ("tv_sec", c_long),         # seconds
+        ("tv_usec", c_long),        # microseconds
+    ]
+
+
+class AdjTimex(Structure):
+    _fields_ = [
+        ("modes", c_int),         # mode selector
+        ("offset", c_long),       # time offset (usec(, nanosec if in NANO mode
+        ("freq", c_long),         # frequency offset (scaled ppm)
+        ("maxerror", c_long),     # maximum error (usec)
+        ("esterror", c_long),     # estimated error (usec)
+        ("status", c_int),        # clock command/status
+        ("constant", c_long),     # pll time constant
+        ("precision", c_long),    # clock precision (usec) (read-only)
+        ("tolerance", c_long),    # clock frequency tolerance (ppm) (read-only)
+        ("time", TimeVal),        # current time (read-only)
+        ("tick", c_long),         # usecs between clock ticks
+        ("ppsfreq", c_long),      # pps frequency (scaled ppm) (ro)
+        ("jitter", c_long),       # pps jitter (us) (ro)
+        ("shift", c_int),         # interval duration (s) (shift) (ro)
+        ("stabil", c_long),       # pps stability (scaled ppm) (ro)
+        ("jitcnt", c_long),       # jitter limit exceeded (ro)
+        ("calcnt", c_long),       # calibration intervals (ro)
+        ("errcnt", c_long),       # calibration errors (ro)
+        ("stbcnt", c_long),       # stability limit exceeded (ro)
+        ("ai", c_int),            # TAI offset (ro)
+    ]
+
+    # MAXPHASE from timex.h, used to be 131071 in Linux 2.6
+    max_time_microsec = 500000
+
+    class Adj:
+        OFFSET = 0x0001      # time offset
+        FREQUENCY = 0x0002   # frequency offset
+        MAXERROR = 0x0004    # maximum time error
+        ESTERROR = 0x0008    # estimated time error
+        STATUS = 0x0010      # clock status
+        TIMECONST = 0x0020   # pll time constant
+        TAI = 0x0080	    # set TAI offset
+        SETOFFSET = 0x0100   # add 'time' to current time
+        MICRO = 0x1000	    # select microsecond resolution
+        NANO = 0x2000	    # select nanosecond resolution
+        TICK = 0x4000	    # tick value
+
+    adj = Adj()
+
+    class Stat:
+        PLL = 0x0001        # enable PLL updates (rw)
+        PPSFREQ = 0x0002    # enable PPS freq discipline (rw)
+        PPSTIME = 0x0004    # enable PPS time discipline (rw)
+        FLL = 0x0008        # select frequency-lock mode (rw)
+        INS = 0x0010        # insert leap (rw)
+        DEL = 0x0020        # delete leap (rw)
+        UNSYNC = 0x0040     # clock unsynchronized (rw)
+        FREQHOLD = 0x0080   # hold frequency (rw)
+        PPSSIGNAL = 0x0100  # PPS signal present (ro)
+        PPSJITTER = 0x0200  # PPS signal jitter exceeded (ro)
+        PPSWANDER = 0x0400  # PPS signal wander exceeded (ro)
+        PPSERROR = 0x0800   # PPS signal calibration error (ro)
+        CLOCKERR = 0x1000   # clock hardware fault (ro)
+        NANO = 0x2000       # resolution (0 = us, 1 = ns) (ro)
+        MODE = 0x4000       # mode (0 = PLL, 1 = FLL) (ro)
+        CLK = 0x8000        # clock source (0 = A, 1 = B) (ro)
+
+    stat = Stat()   # status name was already is taken by fields
+
+    def call(self, verbose=0):
+        # print('call {:x} {:x}'.format(self.modes, self.status)
+        return libc.adjtimex(pointer(self))
+
+    def str_result(self, res):
+        if res < 0:
+            return os.strerror(res)
+        return [
+            "synchronized, no leap second",
+            "insert leap second",
+            "delete leap second",
+            "leap second in progress",
+            "leap second has occurred",
+            "clock not synchronized",
+        ][res]
+
+    def str_status(self):
+        res = []
+        for x in (x for x in dir(self.stat) if x[0] != '_'):
+            if getattr(self.stat, x) & self.status:
+                res.append(x)
+        return ' | '.join(res)
+
+
+def dump_fields(obj, fp, indent=4):
+    prefix = ' ' * indent
+    l = 0
+    # attempt to display nicely
+    for f, t in obj._fields_:
+        if len(f) > l:
+            l = len(f)
+    l += 1
+    for f, t in obj._fields_:
+        v = getattr(obj, f)
+        if hasattr(v, '_fields_'):
+            print('{}{}:'.format(prefix, f))
+            dump_fields(v, fp, indent+2)
+            continue
+        print('{}{:{}} {:>13}'.format(prefix, f+':', l, v))
+
+
+class AdjTime(AdjTimex):
+    def __init__(self):
+        super(AdjTimex, self).__init__()
+        self._verbose = 0
+        self._debug = False
+        self.root = os.getuid() == 0
+        self._nano = None
+
+    @property
+    def nano(self):
+        # property so you don't call adjtimex on import
+        if self._nano is None:
+            self.modes = self.adj.STATUS | self.adj.NANO
+            self.status = self.stat.PLL
+            res = self.call()
+            assert res >= 0
+            self.mode = 0
+            res = self.call()
+            print ("nano setting status {:x}".format(self.status))
+            self._nano = self.status & self.stat.NANO
+        return self._nano
+
+    def update_status(self, mode=0):
+        res = self.call()
+        return res
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, val):
+        self._verbose = val
+
+    @property
+    def debug(self):
+        return self._debug
+
+    @debug.setter
+    def debug(self, val):
+        self._debug = val
+
+    def print_status(self, res=None, count=None):
+        if res is not None:
+            res = str(res) + ' '
+        else:
+            res = ''
+        # 10 because of minus sign
+        s = "{}({}) offset: {:>10} {}, const: {}".format(
+            res,
+            self.str_status(),
+            self.offset,
+            "ns" if self.status & self.adj.NANO else "µs",
+            self.constant)
+        if count is not None:
+            s += ' [{}]'.format(count)
+        print(s)
+        return self.offset
+
+    def test_state_ok(self):
+        _ = self.nano  # to force initializing
+        if self.verbose > 0:
+            print("testing state")
+        assert self.status & self.stat.PLL
+        self.status = 0x0001
+        self.modes = self.adj.STATUS
+        # print(self.call(), self.get_status())
+        if self.status & self.stat.FREQHOLD:
+            if self.debug:
+                print("  FREQHOLD set in adjtimex")
+            else:
+                self.status = 0x2001
+                self.modes = self.adj.STATUS
+                print(self.call())
+                assert not (self.status & self.stat.FREQHOLD)
+
+    def set_offset(self, offset, constant=None):
+        if not self.root:
+            raise NotImplementedError
+        self.offset = offset
+        self.modes = self.adj.OFFSET
+        if constant is not None:
+            self.constant = constant
+            self.modes |= self.adj.TIMECONST
+        return self.call()
+
+    def track_until_zero_offset(self, offset, constant=None, verbose=0):
+        res = self.set_offset(offset, constant=constant)
+        if verbose > 0:
+            print(adjtimex.offset, res)
+        count = 0
+        while True:
+            if verbose > 0:
+                self.print_status(res, count)
+            if res < 0 or adjtimex.offset == 0:
+                break
+            time.sleep(1)
+            adjtimex.modes = AdjTimex.adj.TIMECONST
+            adjtimex.constant = -4
+            adjtimex.call()
+            count += 1
+
+        adjtimex.status = 0x2001
+        adjtimex.modes = adjtimex.adj.STATUS
+        adjtimex.call()
+        if verbose > 0:
+            self.print_status(res, count)
+        return count
+
+    def print_remaining(self, loop_count, nr_loops, rest_time):
+        """print the number of number and total number of loops (partial loops
+        rounded up with the math.ceil() stuff) and an estimated amount of
+        seconds left based on the length of the previous loop and the
+        remaining partial loops. On first invocation rest_time is probalby
+        a string: "unknown"
+        """
+        if isinstance(rest_time, (float, int)):
+            # nr_loops is a float, loop_count one to high
+            rest_time = (nr_loops - loop_count + 1) * rest_time
+            rest_time = int(rest_time)
+            rest_str = "{}s".format(rest_time)
+            if rest_time > 59:
+                rest_str += " ("
+                h, rest_time = divmod(rest_time, 3600)
+                if h:
+                    rest_str += "{}h".format(h)
+                m, rest_time = divmod(rest_time, 60)
+                if h:
+                    rest_str += "{:02}m".format(m)
+                else:
+                    rest_str += "{}m".format(m)
+                rest_str += "{}s".format(rest_time)
+                rest_str += ")"
+        else:
+            rest_str = rest_time
+        # round the number of loops up for the final partial one
+        print('0.5 second loop {}/{}, '
+              'remaining time: {}'.format(
+            loop_count, int(math.ceil(nr_loops)), rest_str))
+
+    def microsec(self, offset, constant=None, pid=None):
+        if constant is None:
+            constant = 0
+        self.nanosec(offset, constant=constant,
+                     pid=pid, mt=self.max_time_microsec)
+
+    def nanosec(self, offset, constant=None, pid=None, mt=None):
+        if constant is None:
+            constant = -4
+        else:
+            constant -= 4  # adjustment for nanoseconds
+        if mt is None:
+            mt = self.max_time_microsec * 1000
+        max_step = mt if offset >= 0 \
+            else -mt
+        looping = True
+        if not self.debug:
+            assert self.root
+        nr_loops = float(offset) / max_step
+        loop_count = 0
+        rest_time = "unknown"
+        while looping:
+            if pid:
+                pid.check()
+            start_time = time.time()
+            if abs(offset) > mt:
+                if pid is None:
+                    if self.verbose > -1:
+                        print('argument to big, use --wait')
+                    sys.exit(errno.EINVAL)
+                loop_count += 1
+                if self.verbose > 0:
+                    self.print_remaining(loop_count, nr_loops, rest_time)
+                # always wait on max
+                self._ns(max_step, constant=constant, wait=True)
+            else:
+                loop_count += 1
+                if self.verbose > 0:
+                    self.print_remaining(loop_count, nr_loops, rest_time)
+                self._ns(offset, constant=constant, wait=pid is not None)
+                looping = False
+            rest_time = time.time() - start_time
+            offset -= max_step
+            if looping and pid:
+                pid.check()
+
+    def _ns(self, offset, constant, wait):
+        if self.verbose > 1:
+            print('this step', offset)
+        # assumed to be in nanoseconds is ADJ_NANO in status
+        self.offset = offset
+        self.modes = self.adj.OFFSET
+        if constant is not None:
+            self.constant = constant
+            self.modes |= self.adj.TIMECONST
+        if not self.debug:
+            res = self.call()
+        else:
+            res = 0
+        count = 0
+        while True:
+            if not wait:
+                break
+            if res < 0 or self.offset == 0:
+                break
+            if self.verbose > 0:
+                self.print_status(res, count)
+            if self.debug:
+                print("debug: exit loop")
+            time.sleep(1)
+            self.modes = AdjTimex.adj.TIMECONST
+            self.constant = constant
+            self.call()
+            count += 1
+
+        self.status = 0x1
+        self.modes = self.adj.STATUS
+        self.call()
+        if self.verbose > 0:
+            self.print_status(res, count)
+        return count
+
+
+adjtime = AdjTime()

--- a/usr/lib/pymodules/python2.7/sdwdate/countaction.py
+++ b/usr/lib/pymodules/python2.7/sdwdate/countaction.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+
+#  Copyright (C) 2014 Anthon van der Neut <anthon@mnt.org>
+#  Copyright (C) 2014 Patrick Schleizer <adrelanos@riseup.net>
+#  See the file COPYING for copying conditions.
+
+import argparse
+
+
+class CountAction(argparse.Action):
+    """argparse action for counting up and down
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--verbose', '-v', action=CountAction, const=1,
+                        nargs=0)
+    parser.add_argument('--quiet', '-q', action=CountAction, const=-1,
+                        nargs=0, dest='verbose',)
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            val = getattr(namespace, self.dest) + self.const
+        except TypeError:  # probably None
+            val = self.const
+        setattr(namespace, self.dest, val)

--- a/usr/lib/pymodules/python2.7/sdwdate/getset_time.py
+++ b/usr/lib/pymodules/python2.7/sdwdate/getset_time.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+
+#  Copyright (C) 2014 Anthon van der Neut <anthon@mnt.org>
+#  Copyright (C) 2014 Patrick Schleizer <adrelanos@riseup.net>
+#  See the file COPYING for copying conditions.
+
+from __future__ import print_function
+
+import os
+import time
+
+import ctypes
+from ctypes import Structure, c_int, c_long, c_void_p, pointer
+
+libc = ctypes.CDLL('librt.so.1')
+libc.adjtimex.argtypes = [c_void_p]
+
+nanoseconds_per_seconds = 1000000000
+
+
+class TimeSpec(Structure):
+    _fields_ = [
+        ("tv_sec", c_long),         # seconds
+        ("tv_nsec", c_long),        # nanoseconds
+    ]
+
+
+class ClockSetTime(TimeSpec):
+    def __call__(self, clk_id, seconds, ns):
+        assert abs(ns) < nanoseconds_per_seconds
+        return self._no_check(clk_id, seconds, ns)
+
+    def ns(self, ns, clk_id=0):
+        return self._no_check(clk_id,
+                              ns // nanoseconds_per_seconds,
+                              ns % nanoseconds_per_seconds)
+
+    def _no_check(self, clk_id, seconds, ns):
+        self.tv_sec = c_long(seconds)
+        print('self.tv_sec', self.tv_sec)
+        self.tv_nsec = c_long(ns)
+        print('self.tv_nsec', self.tv_nsec)
+        return libc.clock_settime(c_int(clk_id), pointer(self))
+
+clock_settime = ClockSetTime()
+
+
+class ClockGetTime(TimeSpec):
+    def __call__(self, clk_id=0):
+        res = libc.clock_gettime(c_int(clk_id), pointer(self))
+        return self.tv_sec, self.tv_nsec
+
+    def ns(self, clk_id=0, v=None):
+        s, ns = self() if v is None else v
+        return s * nanoseconds_per_seconds + ns
+
+    def str(self, v=None):
+        if v is None:
+            v = self()
+        return 'time: {}.{:09d}'.format(*v)
+
+clock_gettime = ClockGetTime()

--- a/usr/lib/pymodules/python2.7/sdwdate/sclockadj.py
+++ b/usr/lib/pymodules/python2.7/sdwdate/sclockadj.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+
+#  Copyright (C) 2014 Anthon van der Neut <anthon@mnt.org>
+#  Copyright (C) 2014 Patrick Schleizer <adrelanos@riseup.net>
+#  See the file COPYING for copying conditions.
+
+from __future__ import print_function
+
+__version__ = "0.1.1"
+
+import sys
+import os
+import argparse
+import signal
+import time
+import subprocess
+import errno
+
+from getset_time import clock_gettime, clock_settime
+from adjtimex import adjtime, dump_fields
+from countaction import CountAction
+
+
+class VPrint:
+    """print depending on verbosity and level"""
+    verbose = 0
+
+    def __init__(self, level=0):
+        self.level = level
+
+    def __call__(self, *args, **kw):
+        lvl = kw.pop('level', self.level)  # required level
+        if self.verbose < lvl:
+            return
+        print(*args, **kw)
+
+vprint = VPrint(level=1)  # print if verbose >= 1
+nprint = VPrint()  # print if verbose >= 0
+
+class PidFile:
+    path = '/run/sdwdate'
+    def __init__(self):
+        self.pid = str(os.getpid())
+        if not os.path.exists(PidFile.path):
+            os.mkdir(PidFile.path)
+        self.file_name = os.path.join(PidFile.path, "sclockadj2")
+        print('writing ', self.file_name)
+        with open(self.file_name, "w") as fp:
+            fp.write(self.pid)
+
+    def check(self, just_check=False):
+        try:
+            with open(self.file_name) as fp:
+                file_pid = fp.read()
+        except IOError:
+            file_pid = 'not available'
+        if just_check:
+            return file_pid == self.pid
+        if file_pid != self.pid:
+            print('pid file differs , file: {}, current: {},'
+                  ' exiting ...'.format(file_pid, self.pid))
+            sys.exit(1)
+
+    def rm_file(self):
+        """remove the file is pid is still the same"""
+        if self.check(just_check=True):
+            os.remove(self.file_name)
+
+class SneakyClockAdjuster:
+    def __init__(self):
+        self.args = None
+        self.subparsers = []
+        self.pid_file = None
+
+    def parse_args(self, cli_args=None):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--test', action="store_true",
+            help=argparse.SUPPRESS,
+        )
+        offset = self.sub_parser(
+            parser, 'offset', cmd=self.cmd_offset,
+            help="change offset (requires UID=0)")
+        offset.add_argument(
+            "nanoseconds",  type=int,  # smart enough to handle -num
+            help="Nanoseconds to add (substract if negative)",)
+        offset.add_argument(
+            "--constant",
+            help="""0 -> fastest autoadjusted for nano/µ sec (default no
+            adjustment)"""
+        )
+        offset.add_argument(  # offset in seconds, for testing
+            '--seconds', action="store_true",
+            help=argparse.SUPPRESS,
+        )
+        status = self.sub_parser(
+            parser, 'status', cmd=self.cmd_status,
+            help="report adjtimex status",
+            description="""adjtimex status (--quiet -> only offset,
+            --verbose -> detail)""",
+        )
+        status.add_argument(
+            "--follow", "-f", action="store_true",
+            help="follow status indefinately"
+        )
+        status.add_argument(
+            "--set", action="store_true",
+            help="set status explicitly to PLL and NANO"
+        )
+
+        for sp in self.subparsers:
+            sp.add_argument(
+                '--verbose', '-v',
+                help='increase verbosity level', action=CountAction,
+                const=1, nargs=0, default=0)
+            sp.add_argument(
+                '--quiet', '-q',
+                help='decrease verbosity level', action=CountAction,
+                const=-1, nargs=0, default=0, dest='verbose')
+            sp.add_argument(
+                '--no-verbose',
+                help=argparse.SUPPRESS, action=CountAction,
+                const=-1, nargs=0, dest='verbose')
+            sp.add_argument(
+                '--debug', '-D', action='store_true',
+                help="Debug messages. Don't change date",)
+            sp.add_argument(
+                '--no-debug', action='store_false', dest="debug",
+                help=argparse.SUPPRESS,)
+            sp.add_argument(
+                "--wait", action='store_true',
+                help="wait for offset to return to 0"
+            )
+
+        parser.add_argument('--version', action='version',
+                            version='%(prog)s ' + __version__)
+        self.args = args = parser.parse_args(args=cli_args)
+        VPrint.verbose = args.verbose
+        if args.debug and args.verbose < 1:
+            args.verbose = 1
+
+    def sub_parser(self, parser, name, help=None, description=None, cmd=None):
+        # first sets up subparsers if necessary
+        sps = getattr(self, '_subparsers', None)
+        if sps is None:
+            sps = self._subparsers = parser.add_subparsers(
+                dest="subparser_name", help='sub-command help')
+        sp = sps.add_parser(name, help=help, description=description)
+        self.subparsers.append(sp)
+        if cmd:
+            sp.set_defaults(func=cmd)
+        return sp
+
+    def cmd_status(self):
+        nprint('status', self.args, level=2)
+        if self.args.set:
+            if not adjtime.root:
+                print("Have to be root to set time")
+                return -1
+            adjtime.modes = adjtime.adj.STATUS | adjtime.adj.NANO
+            adjtime.status = adjtime.stat.PLL
+            # _ = adjtime.nano
+            print ('setting status', adjtime.status)
+            res = adjtime.call()
+        adjtime.modes = 0
+        res = adjtime.call()
+        if self.args.verbose < 0:
+            return "{}".format(adjtime.offset)
+        if self.args.wait or self.args.follow:
+            try:
+                while True:
+                    offset = adjtime.print_status()
+                    if self.args.wait and offset == 0:
+                        return
+                    time.sleep(1)
+                    adjtime.update_status()
+            except KeyboardInterrupt:
+                print('\r     \r', end='')  # clean ^C echo
+            return
+        print('{}:'.format(os.path.basename(sys.argv[0])))
+        print('  result:   {:4x} ({})'.format(res, adjtime.str_result(res)))
+        print('  status: 0x{:4x} ({})'.format(adjtime.status,
+                                              adjtime.str_status()))
+        print('  offset: {}'.format(adjtime.offset))
+        if self.args.verbose > 0:
+            print('  detail:')
+            dump_fields(adjtime, sys.stdout)
+
+    def cmd_offset(self):
+        if not adjtime.root:
+            nprint("Have to be root to set time")
+            if not self.args.debug:
+                return errno.EPERM
+        self.pid_file = PidFile()
+        vprint("Running with PID: {}".format(self.pid_file.pid))
+        if self.args.wait:
+            signal.signal(signal.SIGTERM, self.signal_handler)
+            signal.signal(signal.SIGINT, self.signal_handler)
+
+        adjtime.verbose = self.args.verbose
+        adjtime.debug = self.args.debug
+        adjtime.test_state_ok()
+        if self.args.seconds:
+            self.args.nanoseconds *= 1000000000
+        if adjtime.nano:
+            adjtime.nanosec(self.args.nanoseconds, constant=self.args.constant,
+                            pid=self.pid_file if self.args.wait else None)
+        else:
+            micro, nano = divmod(self.args.nanoseconds, 1000)
+            if micro < 0:  # divmod overshoots on negative numbers
+                micro += 1
+                nano -= 1000
+            if nano:
+                # do first, as we might not want to wait
+                clock_settime.ns(clock_gettime.ns() + nano)
+            adjtime.microsec(micro, constant=self.args.constant,
+                             pid=self.pid_file if self.args.wait else None)
+        self.pid_file.rm_file()
+
+    @staticmethod
+    def signal_handler(signum, frame):
+        print("\rExiting...")
+        if signum == signal.SIGTERM:
+            sys.exit(143)
+        if signum == signal.SIGINT:
+            sys.exit(130)
+
+    def run(self):
+        if self.args.test:
+            #for x in [3671, 75, 10]:
+            #    adjtime.print_remaining(1, 2.0, x)
+            pid_file = PidFile()
+            pid_file.check()
+            return
+        if self.args.func:
+            return self.args.func()
+
+
+def main():
+    n = SneakyClockAdjuster()
+    n.parse_args()
+    sys.exit(n.run())

--- a/usr/lib/sdwdate/sclockadj2
+++ b/usr/lib/sdwdate/sclockadj2
@@ -1,0 +1,10 @@
+#!/usr/bin/env python2.7
+
+import sys
+path="/usr/lib/pymodules/python2.7/"  # not on CentOS
+if path not in sys.path:
+    sys.path.insert(0, path)
+
+from sdwdate.sclockadj import main
+
+main()


### PR DESCRIPTION
- added copyright in headers (pep8 compatible)
- remove None from `status --follow/--wait` and and ns to offset
- complain about non-root status when using 'offset' at verbose level 0 (was 1)
- added PID file (in /run/sdwdate/sclockadj2) exit on removal/change of
  that file
- progress indication x/y + est. seconds remaining after first loop
