### PR TITLE
Switch to v3 onions where possible

### DIFF
--- a/etc/sdwdate.d/30_default.conf
+++ b/etc/sdwdate.d/30_default.conf
@@ -37,9 +37,7 @@ SDWDATE_POOL_ONE=(
          "qn4qfeeslglmwxgb.onion#Lucy Parsons Labs	https://lucyparsonslabs.com/securedrop	https://web.archive.org/web/20170322113502/https://lucyparsonslabs.com/securedrop/"
          "usatodayw7vu5egc.onion#USA Today	https://newstips.usatoday.com/securedrop.html	https://web.archive.org/web/20170419183541/https://newstips.usatoday.com/securedrop.html"
          "mprt35sjunnxfa76.onion#https://informant.taz.de	https://web.archive.org/web/20170329061908/https://informant.taz.de"
-         [
-            "propub3r6espa33w.onion#https://www.propublica.org/nerds/item/a-more-secure-and-anonymous-propublica-using-tor-hidden-services	https://web.archive.org/web/20170420120434/https://www.propublica.org/nerds/item/a-more-secure-and-anonymous-propublica-using-tor-hidden-services"
-         ]
+         "p53lf57qovyuvwsc6xnrppyply3vtqm7l6pcobkmyqsiofyeznfu5uqd.onion#https://www.propublica.org"
          "nrkvarslekidu2uz.onion#NRKbeta	https://www.nrk.no/varsle/	https://web.archive.org/web/20170329103137/https://www.nrk.no/varsle/"
 )
 
@@ -87,7 +85,7 @@ SDWDATE_POOL_THREE=(
          "3kyl4i7bfdgwelmf.onion#http://www.wefightcensorship.org	https://archive.fo/GhgMU"
          "privacyintyqcroe.onion#https://www.privacyinternational.org https://twitter.com/privacyint/status/762656779272593408	https://web.archive.org/web/20170421233214/https:/twitter.com/privacyint/status/762656779272593408"
          "grrmailb3fxpjbwm.onion#https://www.guerrillamail.com https://twitter.com/GuerrillaMail/status/751015957770801152	https://web.archive.org/web/20170421233232/https://twitter.com/GuerrillaMail/status/751015957770801152"
-         "jlve2y45zacpbz6s.onion#https://torstatus.rueckgr.at	https://web.archive.org/web/20170421233243/https://torstatus.rueckgr.at"
+         "t3qi4hdmvqo752lhyglhyb5ysoutggsdocmkxhuojfn62ntpcyydwmqd.onion#https://torstatus.rueckgr.at	https://web.archive.org/web/20200904001100/https://torstatus.rueckgr.at/"
          "expressobutiolem.onion#https://www.expressvpn.com	https://web.archive.org/web/20170420065743/https://www.expressvpn.com"
          "tinhat233xymse34.onion#https://thetinhat.com	https://web.archive.org/web/20170421233308/https://thetinhat.com"
          "rvy6qmlqfstv6rlz.onion#https://www.c3d2.de/news/20160106-c3d2-as-onionservice.html	https://web.archive.org/web/20160807015616/https://www.c3d2.de/news/20160106-c3d2-as-onionservice.html"
@@ -98,21 +96,21 @@ SDWDATE_POOL_THREE=(
          ]
          "crypty22ijtotell.onion#https://cryptoparty.is		https://web.archive.org/web/20161015004023/https://www.cryptoparty.is/"
          [
-            "h2qkxasmmqdmyiov.onion#mail.systemli.org	https://www.systemli.org/en/service/mail.html	https://web.archive.org/web/20161105061658/https://www.systemli.org/en/service/mail.html"
-            "j7652k4sod2azfu6.onion#pad.systemli.org	https://www.systemli.org/en/service/etherpad.html	https://web.archive.org/web/20161105002651/https://www.systemli.org/en/service/etherpad.html"
+            "llqiiswupgezsco4ux47cco3bxsaihbss5c3piefv6bhvpgfofyk7kad.onion#https://mail.systemli.org	https://www.systemli.org/en/service/mail.html	https://web.archive.org/web/20200825072459/https://www.systemli.org/en/service/mail.html"
+            "mjrkrqnlf26etelsi7zpkqc3dzlrzyurvmd3jksmndarzzbugz5xctid.onion#https://pad.systemli.org	https://www.systemli.org/en/service/etherpad.html	https://web.archive.org/web/20191025120405/https://www.systemli.org/en/service/etherpad.html"
          ]
          [
             "2h3xkc7wmxthijqb.onion#https://www.privacyfoundation.ch/de/kontakt.html	https://web.archive.org/web/20151210044252/http://www.privacyfoundation.ch/de/kontakt.html"
             "qcdbc7vspedojrr7.onion#https://www.digitale-gesellschaft.ch/uber-uns/	https://web.archive.org/web/20170415183758/https://www.digitale-gesellschaft.ch/uber-uns/"
          ]
          [
-            "nzh3fv6jc6jskki3.onion#riseup.net:  nzh3fv6jc6jskki3.onion (port 80)"
-            "xpgylzydxykgdqyg.onion#lists.riseup.net: xpgylzydxykgdqyg.onion (port 80)"
-            "zsolxunfmbfuq7wf.onion#mail.riseup.net:     zsolxunfmbfuq7wf.onion (ports 80, 465, 587)"
-            "5jp7xtmox6jyoqd5.onion#pad.riseup.net:   5jp7xtmox6jyoqd5.onion (port 80)"
-            "6zc6sejeho3fwrd4.onion#share.riseup.net:    6zc6sejeho3fwrd4.onion (port 80)"
-            "j6uhdvbhz74oefxf.onion#account.riseup.net:  j6uhdvbhz74oefxf.onion (port 80)"
-            "7lvd7fa5yfbdqaii.onion#we.riseup.net:    7lvd7fa5yfbdqaii.onion (port 443)"
-            "vivmyccb3jdb7yij.onion#0xacab.org:    vivmyccb3jdb7yij.onion (port 80)"
+            "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion#https://riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "7sbw6jufrirhyltzkslhcmkik4z7yrsmbpnptyritvz5nhbk35hncsqd.onion#https://lists.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "5gdvpfoh6kb2iqbizb37lzk2ddzrwa47m6rpdueg2m656fovmbhoptqd.onion#https://mail.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "kfahv6wfkbezjyg4r6mlhpmieydbebr5vkok5r34ya464gqz6c44bnyd.onion#https://pad.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "zs7xwvcspvnnrqhvyxyxpjkihc4lva3yustfr75j6giy24mdfg3rcwqd.onion#https://share.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "3xeiol2bnhrsqhcsaifwtnlqkylrerdspzua7bcjrh26qlrrrctfobid.onion#https://account.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "zkdppoahhqu5ihjqd4qqvyfd2bm4wejrhjosim67t6yopl77jitg2nad.onion#https://we.riseup.net	https://riseup.net/en/security/network-security/tor	https://web.archive.org/web/20200717041213/https://riseup.net/en/security/network-security/tor"
+            "wmj5kiic7b6kjplpbvwadnht2nh2qnkbnqtcv3dyvpqtz7ssbssftxid.onion#https://about.0xacab.org	https://web.archive.org/web/20200629165325/https://about.0xacab.org/"
          ]
 )


### PR DESCRIPTION
Propublica automatically redirects to the v3 onion, Torstatus shows it on the homepage, systemli shows ".onion available" when visiting the clearnet site and the riseup domains are listed [here](https://riseup.net/en/security/network-security/tor)