### PR TITLE
update 20_arch_syscall_whitelist.conf

### DIFF
--- a/lib/systemd/system/sdwdate.service
+++ b/lib/systemd/system/sdwdate.service
@@ -72,7 +72,7 @@ SystemCallArchitectures=native
 ## debian/sdwdate.postinst
 ## https://github.com/Whonix/sdwdate/blob/master/debian/sdwdate.postinst
 ## https://gitlab.com/whonix/sdwdate/blob/master/debian/sdwdate.postinst
-SystemCallFilter=wait4 select futex read stat close openat fstat lseek mmap rt_sigaction getdents64 mprotect ioctl recvfrom munmap brk rt_sigprocmask fcntl getpid write access socket sendto dup2 clone execve getrandom geteuid getgid madvise getuid getegid readlink pipe rt_sigreturn connect pipe2 prlimit64 set_robust_list dup arch_prctl lstat set_tid_address sysinfo sigaltstack rt_sigsuspend shutdown timer_settime mkdir timer_create statfs getcwd setpgid setsockopt uname bind getpgrp getppid getpeername chdir poll getsockname fadvise64 clock_settime kill getsockopt unlink epoll_create1 utimensat
+SystemCallFilter=wait4 select futex read stat close openat fstat lseek mmap rt_sigaction getdents64 mprotect ioctl recvfrom munmap brk rt_sigprocmask fcntl getpid write access socket sendto dup2 clone execve getrandom geteuid getgid madvise getuid getegid readlink pipe rt_sigreturn connect pipe2 prlimit64 set_robust_list dup arch_prctl lstat set_tid_address sysinfo sigaltstack rt_sigsuspend shutdown timer_settime mkdir timer_create statfs getcwd setpgid setsockopt uname bind getpgrp getppid getpeername chdir poll getsockname fadvise64 clock_settime kill getsockopt unlink epoll_create1 utimensat unlinkat
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
unlinkat needs to be whitelisted otherwise sdwdate fails with error: `SECCOMP auid=4294967295 uid=102 gid=108 ses=4294967295 subj==/usr/bin/sdwdate (enforce) pid=3328 comm="sdwdate" exe="/usr/bin/python3.9" sig=31 arch=c00000b7 syscall=35 compat=0 ip=0xf37077846c74 code=0x80000000`