### PR TITLE
update 20_arch_syscall_whitelist.conf

### DIFF
--- a/debian/sdwdate.postinst
+++ b/debian/sdwdate.postinst
@@ -96,7 +96,7 @@ if [[ "${arch}" =~ "arm" ]] || [[ "${arch}" =~ "aarch" ]]; then
    ## ARM-specific syscalls.
    syscall_whitelist="\
 [Service]
-SystemCallFilter=faccessat readlinkat newfstatat mkdirat dup3 ppoll pselect6"
+SystemCallFilter=faccessat readlinkat newfstatat mkdirat dup3 ppoll pselect6 unlinkat"
 elif [[ "${arch}" =~ "ppc" ]]; then
    ## PowerPC-specific syscalls.
    syscall_whitelist="\


### PR DESCRIPTION
unlinkat needs to be whitelisted otherwise sdwdate fails with error: SECCOMP auid=4294967295 uid=102 gid=108 ses=4294967295 subj==/usr/bin/sdwdate (enforce) pid=3328 comm="sdwdate" exe="/usr/bin/python3.9" sig=31 arch=c00000b7 syscall=35 compat=0 ip=0xf37077846c74 code=0x80000000