### PR TITLE
Fix syscall whitelist for bookworm on ppc64el

### DIFF
--- a/debian/sdwdate.postinst
+++ b/debian/sdwdate.postinst
@@ -101,7 +101,7 @@ elif [[ "${arch}" =~ "ppc" ]]; then
    ## PowerPC-specific syscalls.
    syscall_whitelist="\
 [Service]
-SystemCallFilter=_llseek send waitpid recv prctl _newselect"
+SystemCallFilter=_llseek send waitpid recv prctl _newselect newfstatat pselect6"
 elif [[ "${arch}" =~ "x86" ]]; then
    syscall_whitelist="\
 ## Default. No changes required."


### PR DESCRIPTION
Both added syscalls were already whitelisted for ARM.  It's not obvious to me why they only started mattering for ppc64el on Bookworm and higher (Bullseye unaffected), but seems worth fixing.