### PR TITLE
Fix syscall whitelist for Python 3.10.x on PowerPC

### DIFF
--- a/debian/sdwdate.postinst
+++ b/debian/sdwdate.postinst
@@ -101,7 +101,7 @@ elif [[ "${arch}" =~ "ppc" ]]; then
    ## PowerPC-specific syscalls.
    syscall_whitelist="\
 [Service]
-SystemCallFilter=_llseek send waitpid recv prctl _newselect newfstatat pselect6"
+SystemCallFilter=_llseek send waitpid recv prctl _newselect newfstatat pselect6 vfork"
 elif [[ "${arch}" =~ "x86" ]]; then
    syscall_whitelist="\
 ## Default. No changes required."


### PR DESCRIPTION
Necessary for Debian Sid ppc64 and ppc64el.  I have no idea whether a similar change is needed on x86 or ARM.  Also no idea what attack surface is introduced by that syscall.